### PR TITLE
add left_margin (and left_margin_width), mention_show_bg options

### DIFF
--- a/config_default.lua
+++ b/config_default.lua
@@ -12,6 +12,11 @@ config.color.clock = "38;5;8"
 config.color.in_messages = true
 if os.getenv("NO_COLOR") then config.color = {} end -- https://no-color.org
 
+config.mention_show_bg = false -- toggles color background for mentions of your nickname
+
+config.left_margin = false -- all (most) messages starting at the same column, some empty space on the left
+config.left_margin_width = 20
+
 config.timefmt = "%H:%M "
 
 config.quit_msg = "oki goodnite uwu  >.<"

--- a/util.lua
+++ b/util.lua
@@ -10,15 +10,21 @@ function djb2(s)
 	return hash
 end
 
-function hi(s) -- highlight
+function hi(s, mention) -- highlight
 	if not s then return "" end
 	local colors = config.color.nicks
-	if not colors or #colors == 0 then return s end
-
+	local bg = config.mention_show_bg
+	local modifiers = {}
 	-- TODO highlighting commands in help prompts?
-	local cid = djb2(s) % #colors
-	local color = colors[cid+1]
-	return "\x1b["..color.."m"..s.."\x1b[0m"
+	if (colors and #colors ~= 0) then
+		local cid = djb2(s) % #colors
+		local color = colors[cid+1]
+		table.insert(modifiers, color)
+	end
+	if (mention and bg) then
+		table.insert(modifiers, "3")
+	end
+	return "\x1b["..table.concat(modifiers, ";").."m"..s.."\x1b[0m"
 end
 
 function nick_pattern(nick)


### PR DESCRIPTION
Adding two optional cosmetic features disabled by default, and making the code a bit messier:
- config.left_margin (plus config.left_margin_width), making the interface more similar to certain other irc client
- config.mention_show_bg, making it easier to notice when the user's nickname appears in the chat